### PR TITLE
docs: add .claude/settings.local.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ tmp/
 temp/
 *.tmp
 tests/tmp/
+
+# Claude Code local settings
+.claude/settings.local.json


### PR DESCRIPTION
## 概要

`.claude/settings.local.json`を`.gitignore`に追加して、ローカル設定の誤コミットを防止します。

## 変更内容

`.gitignore`に以下を追加：

```gitignore
# Claude Code local settings
.claude/settings.local.json
```

## 背景

Claude Codeの設定ファイルには2種類あります：

| ファイル | 用途 | Git管理 |
|---------|------|---------|
| `.claude/settings.json` | プロジェクト共有設定 | ✅ コミット対象 |
| `.claude/settings.local.json` | 開発者個人の設定 | ❌ gitignore対象 |

現在、`settings.local.json`には個人のパーミッション設定が含まれており、これをコミットするとチーム開発時に混乱を招く可能性があります。

## テスト

- [x] `.gitignore`の構文が正しいことを確認
- [x] `git status`で`settings.local.json`が表示されないことを確認

## 関連イシュー

Closes #4

## チェックリスト

- [x] 変更内容が明確
- [x] コミットメッセージがConventional Commits形式
- [x] イシューをクローズする記述を含む