### PR TITLE
feat: expand default file patterns to support .js, .jsx, .ts, .tsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install test-kanteen
 #### テスト観点カタログ生成
 
 ```bash
-# 最もシンプルな使い方（デフォルト: **/*.test.ts, json+markdown出力）
+# 最もシンプルな使い方（デフォルト: **/*.{test,spec}.{js,jsx,ts,tsx}, json+markdown出力）
 npx kanteen
 
 # または明示的にanalyzeを指定
@@ -50,17 +50,17 @@ npx kanteen analyze --config kanteen.config.js
 #### 関数・クラスの抽出 🆕
 
 ```bash
-# 最もシンプルな使い方（デフォルト: **/*.{ts,tsx}, json+markdown出力）
+# 最もシンプルな使い方（デフォルト: **/*.{js,jsx,ts,tsx}, json+markdown出力）
 npx kanteen extract
 
 # 特定のパターンを指定
 npx kanteen extract "src/**/*.ts"
 
 # オプション
-npx kanteen extract "lib/**/*.{ts,tsx}" --output ./exports --format json
+npx kanteen extract "lib/**/*.{js,jsx,ts,tsx}" --output ./exports --format json
 ```
 
-**抽出対象**: 関数、クラス、メソッド（export/export default対応、.ts/.tsx両対応）
+**抽出対象**: 関数、クラス、メソッド（export/export default対応、.js/.jsx/.ts/.tsx対応）
 詳細: [Extract機能ガイド](./docs/EXTRACT_GUIDE.md)
 
 #### ランタイムカタログ生成 🆕
@@ -272,7 +272,7 @@ await reporter.writeToFile('./test-reports/github.md');
 
 ```javascript
 export default {
-  include: ['**/*.test.ts', '**/*.spec.ts'],
+  include: ['**/*.{test,spec}.{js,jsx,ts,tsx}'],
   exclude: ['**/node_modules/**'],
   framework: 'auto',
   reporters: ['json', 'markdown'],

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,7 +17,7 @@ program
 program
   .command('analyze')
   .description('テストファイルを解析してカタログを生成')
-  .argument('[pattern]', 'テストファイルのパターン', '**/*.test.ts')
+  .argument('[pattern]', 'テストファイルのパターン', '**/*.{test,spec}.{js,jsx,ts,tsx}')
   .option('-c, --config <path>', '設定ファイルのパス')
   .option('-o, --output <path>', '出力先ディレクトリ', './aaa_test_kanteen')
   .option('-f, --format <formats>', '出力フォーマット (json,yaml,markdown)', 'json,markdown')
@@ -120,7 +120,7 @@ program
 program
   .command('extract')
   .description('ソースコードから関数・クラスを抽出')
-  .argument('[pattern]', 'ソースファイルのパターン', '**/*.{ts,tsx}')
+  .argument('[pattern]', 'ソースファイルのパターン', '**/*.{js,jsx,ts,tsx}')
   .option('-o, --output <path>', '出力先ディレクトリ', './aaa_test_kanteen/exports')
   .option('-f, --format <formats>', '出力フォーマット (json,markdown)', 'json,markdown')
   .option('-v, --verbose', '詳細な出力を表示')
@@ -494,7 +494,7 @@ function generateTypeScriptConfig(): string {
   return `import type { KanteenConfig } from 'test-kanteen';
 
 const config: KanteenConfig = {
-  include: ['**/*.test.ts', '**/*.spec.ts'],
+  include: ['**/*.{test,spec}.{js,jsx,ts,tsx}'],
   exclude: ['**/node_modules/**', '**/dist/**'],
   framework: 'auto',
   reporters: ['json', 'markdown'],
@@ -515,7 +515,7 @@ export default config;
 function generateJavaScriptConfig(): string {
   return `/** @type {import('test-kanteen').KanteenConfig} */
 const config = {
-  include: ['**/*.test.js', '**/*.spec.js'],
+  include: ['**/*.{test,spec}.{js,jsx,ts,tsx}'],
   exclude: ['**/node_modules/**', '**/dist/**'],
   framework: 'auto',
   reporters: ['json', 'markdown'],


### PR DESCRIPTION
## Summary
- Expanded default file patterns to support JavaScript and JSX files alongside TypeScript
- Updated `analyze` command default: `**/*.{test,spec}.{js,jsx,ts,tsx}`
- Updated `extract` command default: `**/*.{js,jsx,ts,tsx}`
- Updated config generation templates for both JavaScript and TypeScript
- Updated README.md documentation to reflect new patterns

## Rationale
The parser already supports JSX/TSX with `jsx: true` configuration, but the default patterns only covered TypeScript files. This change makes test-kanteen more accessible to JavaScript projects and mixed codebases.

## Test Plan
- ✅ All 188 tests passing
- ✅ Build successful
- ✅ Linting clean (0 errors, 113 acceptable warnings)

## Changes
### src/cli/index.ts
- analyze command default pattern: `**/*.test.ts` → `**/*.{test,spec}.{js,jsx,ts,tsx}`
- extract command default pattern: `**/*.{ts,tsx}` → `**/*.{js,jsx,ts,tsx}`
- TypeScript config template: `['**/*.test.ts', '**/*.spec.ts']` → `['**/*.{test,spec}.{js,jsx,ts,tsx}']`
- JavaScript config template: `['**/*.test.js', '**/*.spec.js']` → `['**/*.{test,spec}.{js,jsx,ts,tsx}']`

### README.md
- Updated all usage examples to show new default patterns
- Updated extract target description to mention .js/.jsx support

🤖 Generated with [Claude Code](https://claude.com/claude-code)